### PR TITLE
makefile: fix adb-pull target to be more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 adb-getversion:
-	@adb shell dumpsys package com.google.android.inputmethod.latin | grep "versionName=" | cut -d = -f2
+	@adb shell dumpsys package com.google.android.inputmethod.latin | grep "versionName=" | cut -d = -f2 | head -n1
 
 adb-pull:
-	adb shell su root rm -rf /sdcard/gboard-temp \&\& mkdir -p /sdcard/gboard-temp
-	adb shell su root tar -czvf /sdcard/gboard-temp/data.tar.gz /data/data/com.google.android.inputmethod.latin/
-	adb shell su root chown $(shell adb shell stat -L -c "%U:%G" /sdcard) -R /sdcard/gboard-temp
+	adb shell su root -c 'rm -rf /sdcard/gboard-temp \&\& mkdir -p /sdcard/gboard-temp'
+	adb shell su root -c 'tar -czvf /sdcard/gboard-temp/data.tar.gz /data/data/com.google.android.inputmethod.latin/'
+	adb shell su root -c 'chown $(shell adb shell stat -L -c "%U:%G" /sdcard) -R /sdcard/gboard-temp'
 	adb pull /sdcard/gboard-temp gboard-data-$(shell make adb-getversion)
-	adb shell su root rm -rf /sdcard/gboard-temp
+	adb shell su root -c 'rm -rf /sdcard/gboard-temp'


### PR DESCRIPTION
This makes su compliant with other binaries and it will report
only the latest gboard version if multiple found.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>