### PR TITLE
serialization: empty lists are reported as `null` instead of `[]`

### DIFF
--- a/source/gboardforensics/models/clipboard.d
+++ b/source/gboardforensics/models/clipboard.d
@@ -1,5 +1,6 @@
 module gboardforensics.models.clipboard;
 
+import gboardforensics.utils.serialization;
 import asdf.serialization;
 
 /**
@@ -38,5 +39,5 @@ struct Clipboard
 	/// path to the dictionary
 	immutable string path;
 	/// list of dictionary entries
-	const(Entry)[] entries;
+	SerializableArray!(const(Entry)) entries;
 }

--- a/source/gboardforensics/models/dictionary.d
+++ b/source/gboardforensics/models/dictionary.d
@@ -1,5 +1,7 @@
 module gboardforensics.models.dictionary;
 
+import gboardforensics.utils.serialization;
+
 /**
  * This represents a personal dictionary data structure
  */
@@ -30,10 +32,17 @@ struct Dictionary
 		return entries.length;
 	}
 
+	@safe pure nothrow @nogc
+	this(string path, const(Entry)[] entries)
+	{
+		this.path = path;
+		this.entries = entries;
+	}
+
 	/// path to the dictionary
 	immutable string path;
 	/// list of dictionary entries
-	const(Entry)[] entries;
+	SerializableArray!(const(Entry)) entries;
 }
 
 ///

--- a/source/gboardforensics/models/trainingcache.d
+++ b/source/gboardforensics/models/trainingcache.d
@@ -1,5 +1,7 @@
 module gboardforensics.models.trainingcache;
 
+import gboardforensics.utils.serialization;
+
 import std.typecons : Nullable;
 
 import asdf.serialization : serdeIgnore, serdeIgnoreDefault;
@@ -28,16 +30,16 @@ struct TrainingCache
 	immutable string path;
 
 	/// All keystrokes.
-	const(Info)[] inserted;
+	SerializableArray!(const(Info)) inserted;
 
 	/// All deleted sequences.
-	const(Info)[] deleted;
+	SerializableArray!(const(Info)) deleted;
 
 	/// All keystrokes pressed and deleted by the order in which they were performed.
-	const(Info)[] historyTimeline;
+	SerializableArray!(const(Info)) historyTimeline;
 
 	/// All information in HistoryTimeline assembled together for easier readability.
-	const(Info)[] assembledTimeline;
+	SerializableArray!(const(Info)) assembledTimeline;
 
 	/**
 	Contains similar information to History but with some sequences removed. The
@@ -58,7 +60,7 @@ struct TrainingCache
 	  this method might be the output 'helllo word'.
 	---
 	*/
-	const(Info)[] processedHistory;
+	SerializableArray!(const(Info)) processedHistory;
 }
 
 ///

--- a/source/gboardforensics/utils/serialization.d
+++ b/source/gboardforensics/utils/serialization.d
@@ -1,0 +1,50 @@
+module gboardforensics.utils.serialization;
+
+import asdf.serialization;
+
+/**
+ * Array wrapper to make null arrays serializable as empty arrays
+ */
+struct SerializableArray(T)
+{
+	/// Array data
+	public T[] data;
+	alias data this;
+
+	/**
+	 * Constructs a serializable array from a given normal array
+	 *
+	 * Params:
+	 *   data = array to wrap
+	 */
+	this(T[] data)
+	{
+		this.data = data;
+	}
+
+	/**
+	 * Custom array serializer for asdf
+	 *
+	 * Params:
+	 *   serializer = JSON serializer
+	 */
+	void serialize(S)(ref S serializer) const
+	{
+		auto valState = serializer.arrayBegin();
+		foreach (ref elem; data)
+		{
+			serializer.elemBegin;
+			serializer.serializeValue(elem);
+		}
+		serializer.arrayEnd(valState);
+	}
+}
+
+pure
+unittest
+{
+	SerializableArray!int b;
+
+	assert(b == []);
+	assert("[]" == b.serializeToJson!());
+}


### PR DESCRIPTION
Fixes #24 .

Signed-off-by: Luís Ferreira <contact@lsferreira.net>