### PR TITLE
github: workflows: allow codecov step to fail and continue

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,8 +42,7 @@ jobs:
           dub test --build=unittest-cov
 
       - name: Upload coverage
-        continue-on-error: true
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.0.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,6 +42,7 @@ jobs:
           dub test --build=unittest-cov
 
       - name: Upload coverage
+        continue-on-error: true
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

No more heisenberg's from Codecov :angry: 